### PR TITLE
FIX: Duplicating QL Toolbar

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,7 +1,7 @@
 import TextEditor from "./TextEditor";
 
 function App() {
-  return <TextEditor />;
+   return <TextEditor />;
 }
 
 export default App;

--- a/client/src/TextEditor.js
+++ b/client/src/TextEditor.js
@@ -1,11 +1,16 @@
-import React from 'react'
-import { useEffect } from 'react';
+import React from "react";
+import { useCallback } from "react";
 import Quill from "quill";
 import "quill/dist/quill.snow.css";
 
 export default function TextEditor() {
-    useEffect(() => { // useEffect is a hook that runs when the component is mounted. This makes it so that the editor is only rendered once the component is mounted.
-        new Quill("#container", { theme: "snow" }) // This creates a new Quill object and renders it in the div with id="container".
-    }, [])
-    return <div id="container"></div>
+   const wrapperRef = useCallback(wrapper => { // This creates a reference to the div with id="container".
+      if (wrapper == null) return; // If the div with id="container" does not exist, then return.
+
+      wrapper.innerHTML = ""; // This clears the div with id="container".
+      const editor = document.createElement("div"); // This creates a div element.
+      wrapper.append(editor); // This appends the div element to the div with id="container".
+      new Quill(editor, { theme: "snow" }); // This creates a Quill object.
+   }, []);
+   return <div id="container" ref={wrapperRef}></div>
 }

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,10 +1,10 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import App from './App';
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
+	<React.StrictMode>
+		<App />
+	</React.StrictMode>
 );


### PR DESCRIPTION
The old code has a bug that causes a new Quill toolbar to be added to the website every time there is a change. This is because the code doesn't handle the cleanup of the previous Quill instance before creating a new one.
Here's how the second code snippet fixes the bug:

The `useCallback` hook is used to create a memoized callback function, `wrapperRef`, which references the `div` element with the `id "container"`. It takes a parameter `wrapper`, which represents the referenced element.

Inside the `wrapperRef callback` function, the first condition checks if `wrapper` is null, indicating that the referenced element doesn't exist. In such a case, the function returns early to prevent further execution.

If the `wrapper` element exists, the next step is to clear its content by setting `wrapper.innerHTML` to an empty string. This ensures that any previous content is removed.

A new `div` element, editor, is created using `document.createElement("div")`.

The editor element is appended to the `wrapper` element using `wrapper.append(editor)`. This ensures that the editor is rendered inside the div with the `id "container"`.

Finally, a new instance of the Quill object is created by passing the editor element as the first argument, and an options object specifying the theme as `"snow"`.

By using this approach, the previous Quill instance is properly cleaned up before creating a new one. The content of the `wrapper` element is cleared, and a new div element is created to serve as the container for the Quill editor.