### PR TITLE
3 the toolbar appears when printing the page in the browser

### DIFF
--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -36,3 +36,7 @@ body {
     border: none;
     box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.5);
 }
+
+@page {
+    margin: 1in;
+}

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -40,3 +40,9 @@ body {
 @page {
     margin: 1in;
 }
+
+@media print {
+    body {
+        background: none;
+    }
+}

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -46,6 +46,16 @@ body {
         background: none;
     }
 
+    .container .ql-editor {
+        width: 6.5in;
+        height: 9in;
+        padding: 0;
+        margin: 0;
+        box-shadow: none;
+        align-self: flex-start;
+    
+    }
+
     .container .ql-toolbar.ql-snow {
         display: none;
     }

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -45,4 +45,8 @@ body {
     body {
         background: none;
     }
+
+    .container .ql-toolbar.ql-snow {
+        display: none;
+    }
 }


### PR DESCRIPTION
This code fix the problem of showing the toolbar on the print action by simply, on the print action, defining the `.container .ql-toolbar.ql-snow` as `display: none;`. The rest of the commits is to style it a bit better.